### PR TITLE
Minor cleanup of AzureDevops api usage

### DIFF
--- a/src/providers/devops.rs
+++ b/src/providers/devops.rs
@@ -46,9 +46,6 @@ impl AzureDevopsProvider {
             .client
             .pull_requests_client()
             .get_pull_requests_by_project(&self.organization, &self.project)
-            .send()
-            .await?
-            .into_body()
             .await?;
 
         let todos = res


### PR DESCRIPTION
Just a minor cleanup/simplification in your usage of the azure-devops crate API (disclosure... I'm the author).

Recent changes to the API mean that you can now just invoke `.await` on the operation to get the parsed response.